### PR TITLE
Add LocalLoraGalleryStacker node.

### DIFF
--- a/js/Local_Lora_Gallery.js
+++ b/js/Local_Lora_Gallery.js
@@ -95,7 +95,7 @@ const LocalLoraGalleryNode = {
             this.size = [700, 600];
             this.loraData = [];
             this.availableLoras = [];
-            this.isModelOnly = nodeData.name.includes("ModelOnly");
+            this.isModelOnly = nodeData.name.includes("ModelOnly") || nodeData.name.includes("Stacker");
             this.selectedCardsForEditing = new Set(); 
 
             const node_instance = this;
@@ -1202,10 +1202,15 @@ const LocalLoraGalleryNode = {
 };
 
 app.registerExtension({
-    name: "LocalLoraGallery.GalleryUI",
-    async beforeRegisterNodeDef(nodeType, nodeData) {
-        if (nodeData.name === "LocalLoraGallery" || nodeData.name === "LocalLoraGalleryModelOnly") {
-            LocalLoraGalleryNode.setup(nodeType, nodeData);
-        }
-    },
+	name: "LocalLoraGallery.GalleryUI",
+	async beforeRegisterNodeDef(nodeType, nodeData) {
+		if (
+			nodeData.name === "LocalLoraGallery" ||
+			nodeData.name === "LocalLoraGalleryModelOnly" ||
+			nodeData.name === "LocalLoraGalleryStacker"
+		) {
+			LocalLoraGalleryNode.setup(nodeType, nodeData);
+		}
+	},
 });
+


### PR DESCRIPTION
Based on my issue requesting a new type of node [here](https://github.com/Firetheft/ComfyUI_Local_Lora_Gallery/issues/16#issue-3850420219), i created a new node to solve it.

This pull request adds a node called LocalLoraGalleryStacker:

- No inputs.
- Outputs:
  - lora_stacker;
  - active_loras;
  - trigger_words;

Below are examples of outputs:

* **lora_stack**
```
[
    [
        "lora_a.safetensors",
        0.4,
        0.4
    ],
    [
        "loras_subdirectory1/lora_b.safetensors",
        0.6,
        0.6
    ],
    [
        "loras_subdirectory2/lora_c.safetensors",
        1.0,
        1.0
    ]
]
```

* **active_loras**
```
<lora:lora_a:0.4> <lora:lora_b:0.6> <lora:lora_c:1.0>
```

* **trigger_words**
```
word_a, word_b, word_c, 
```